### PR TITLE
Fix response undefined exception

### DIFF
--- a/src/airbase-controller.js
+++ b/src/airbase-controller.js
@@ -125,6 +125,10 @@ class DaikinAircon {
                 }
             }
         }
+        
+        if (!response) {
+            throw `Request failed after ${RETRY_ATTEMPTS} attempts`;
+        }
 
         if (!response.ok) {
             throw response.status;

--- a/src/airbase-controller.js
+++ b/src/airbase-controller.js
@@ -127,7 +127,7 @@ class DaikinAircon {
         }
         
         if (!response) {
-            throw `Request failed after ${RETRY_ATTEMPTS} attempts`;
+            throw `Maximum retry attempts (${RETRY_ATTEMPTS}) reached, bailing out`;
         }
 
         if (!response.ok) {


### PR DESCRIPTION
If `fetch` fails after 3 retry attempts, `response` will be `undefined`.

Executing `response.ok` will throw exception.

Fixes https://github.com/yenoiwesa/homebridge-daikin-airbase/issues/49